### PR TITLE
Fix linux build error

### DIFF
--- a/gilrs-core/src/platform/linux/gamepad.rs
+++ b/gilrs-core/src/platform/linux/gamepad.rs
@@ -687,7 +687,7 @@ impl Gamepad {
     }
 
     pub fn mount_point(&self) -> Option<String> {
-        Some(self.devpath)
+        Some(self.devpath.to_owned())
     }
 
     pub fn buttons(&self) -> &[EvCode] {


### PR DESCRIPTION
There was an error building in Linux because Strings don't implement Copy